### PR TITLE
Updated Project and Subsidy data with APSH and DCHA info

### DIFF
--- a/Prog/Check_APSH_2016_06.sas
+++ b/Prog/Check_APSH_2016_06.sas
@@ -1,0 +1,76 @@
+/**************************************************************************
+ Program:  Check_APSH_PH_062016.sas
+ Library:  PresCat
+ Project:  NeighborhoodInfo DC
+ Author:   K. Abazajian
+ Created:  06/16/2016
+ Version:  SAS 9.2
+ Environment:  Local Windows session (desktop)
+ 
+ Description:  Read in local APSH dataset and compare to PresCat subsidy data
+
+ Modifications:
+**************************************************************************/
+
+%include "L:\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( PresCat, local=n, rreadonly=n )
+libname raw "D:\DCData\Libraries\PresCat\Raw";\
+
+%let outlib = %mif_select( &_remote_batch_submit, PresCat, WORK );
+
+/*Flag NLIHC_IDs with Public Housing as program (some receive other subs)*/
+data subsidy_pubhsng (keep=Nlihc_id pubhsng);
+set PresCat.subsidy;
+if program ~= "PUBHSNG " then delete;
+pubhsng=1;
+run;
+
+/*Merge flag onto all subsidies*/
+data all_subsidy_pubhsng;
+merge PresCat.subsidy subsidy_pubhsng PresCat.project(keep=nlihc_id proj_name Proj_Addre);
+by nlihc_id;
+if pubhsng~=1 then delete;
+run;
+
+/*Merge one-time data pull [year] APSH data in SAS dataset filetype*/
+data hudPicture2015_DC;
+set raw.hudPicture2015_DC;
+name=propcase(name);
+run;
+
+proc sort data=hudPicture2015_DC;by name;run;
+
+proc sort data=all_subsidy_pubhsng; by proj_name;run;
+
+/*First visual check for projects in APSH program=Public Housing, pubhsng~=1*/
+data APSH_subsidy_check;
+merge all_subsidy_pubhsng(in=a) hudPicture2015_DC(rename=(name=proj_name));
+by proj_name;
+run;
+/*Second visual check for projects in catalog where pubhsng=1, APSH program~=Public Housing*/
+data APSH_subsidy_check_2;
+set APSH_subsidy_check;
+if pubhsng~=1 then delete;
+run;
+
+
+/*VISUAL CHECK of subsidy_check data
+
+2015 APSH Notes 
+(projects in APSH as PH, not in catalog): 
+1475 Columbia Rd 
+Nannie Helen Burroughs 
+Edgewood Terrace Seniors Development(Edgewood III is in catalog as PH, not seniors)
+Matthews Memorial Terrace Apartments 
+Sheridan Station Phase I (Multifamily) 
+Victory Square Senior Apartments
+
+(projects in catalog as PH, different in APSH):
+Sursum Corda NL000287 in APSH as Section 8
+
+
+Other discrepancies were updated in DCData\Libraries\PresCat\Prog\Updates\Update_DCHA_Document_2016_04.sas
+*/
+

--- a/Prog/Updates/Update_DCHA_Document_2016_04.sas
+++ b/Prog/Updates/Update_DCHA_Document_2016_04.sas
@@ -1,0 +1,80 @@
+libname prescat "L:\Libraries\PresCat\Data";
+options nofmterr;
+
+data subs;
+set prescat.subsidy; 
+*Capitol Gateway Senior Estates;
+if Nlihc_id= "NL001000" & Portfolio="PUBHSNG" then delete;
+*Capitol Gateway Townhomes part of single family;
+if nlihc_id = "NL000375" then delete;
+*Fort lincoln no LIHTC all pub housing;
+if nlihc_id = "NL000110" & program="LIHTC" then delete; 
+*Capper Senior duplicate;
+if nlihc_id = "NL001019" then delete;
+*Added new subsidy row(subsidy_id=5) for PUBHSNG Glenncrest, 61 units;
+*Henson UFAs;
+if nlihc_id = "NL000388" & Subsidy_id=3 then Units_Assist=22 ;
+*Added new subsidy row (subsidy_id=5) for PUBHSNG Gibson Plaza, 53 units;
+*Added new subsidy rows (subsidy_id=3,4) for PUBHSNG and LIHTC Phyllis Wheatley, 76 and 6 units resp.;
+*Pollin memorial;
+if nlihc_id="NL000353" & subsidy_id=1 then do;
+	Program="PUBHSNG";
+	Subsidy_Info_Source = "DCHA Document";
+end;
+*Added new subsidy rows (subsidy_id=4) for PUBHSNG St. Martin's, 50 out of 178 total units;
+*The Avenue;
+if nlihc_id = "NL000225" then Units_Assist=27;
+*Added new subsidy row (subsidy_id=2) for LIHTC The Avenue, 83 units;
+*Triangle View;
+if nlihc_id="NL000419" then Units_Assist=25;
+*Williston; 
+if nlihc_id="NL000303" & subsidy_id=2 then do; 
+ Subsidy_Info_Source="DCHA Document";
+ Program="PUBHSNG";
+ end;
+
+*FROM APSH;
+if Nlihc_id="NL000034" then do;Units_Assist=439;Subsidy_Info_Source="APSH";end;*previous source-DCHA website;
+if nlihc_id="NL000043" then do;Units_Assist=284;Subsidy_Info_Source="APSH";end;
+
+run;
+data proj;
+set prescat.project;
+/*Parkway Overlook ownership*/
+if Nlihc_id= "NL000234" then Hud_Own_Name="Parkway Overlook, LP (DCHA affiliate)";
+*Capitol Gateway Townhomes part of single family;
+if nlihc_id = "NL000375" then delete;
+*Capper Senior duplicate;
+if nlihc_id = "NL001019" then delete;
+*Glenncrest;
+if nlihc_id = "NL000085" then Proj_Units_Tot=61;
+*Henson UFAs;
+if nlihc_id = "NL000388" then Proj_Units_Assist_Max=22 ;
+if nlihc_id = "NL000388" then Hud_Mgr_Name="Edgewood Management Corporation";
+*Highland Dwellings;
+if nlihc_id = "NL000157" then Hud_Mgr_Name="CIH Properties, Inc." & Hud_Own_Name="Highland Dwellings Residential, LP";
+*Phyllis Wheatley - note HPTF subsidy says it covers 117 units, left in subsidy file;
+if nlihc_id="NL000242" then Proj_Units_Tot=84;
+if nlihc_id="NL000242" then Proj_Units_Assist_Min = 6; 
+*St. Martin;
+if nlihc_id = "NL000384" then Proj_Units_Assist_Min=50;
+*The Avenue;
+if nlihc_id = "NL000225" then Proj_Units_Assist_Min=27;
+if nlihc_id = "NL000225" then Proj_Units_assist_Max=83;
+*Triangle View;
+if nlihc_id="NL000419" then Proj_Units_Tot=100;
+if nlihc_id="NL000419" then Proj_Units_Assist_Min=25;
+*Williston;
+if nlihc_id="NL000303" then do;
+	Proj_Units_Tot=28;
+	Proj_Units_Assist_Min=28;
+	Proj_Units_Assist_Max=28;
+end;
+
+run;
+*To add to catalog: 
+1475 Columbia Rd , Public Housing
+Nannie Helen Burroughs, Public Housing
+Matthews Memorial Terrace Apartments, Public Housing
+Sheridan Station Phase I (Multifamily), PH
+Victory Square Senior Apartments , PH


### PR DESCRIPTION
Compared data between APSH, DCHA, Project, and Subsidy data. Updated
Project and Subsidy files with all DCHA suggestions. Updated Project and
Subsidy files with APSH data not conflicting with administrative data
(only if informal source). Noted remaining differences in program
commetns. Will post remaining differences (projects not in catalog) in
note on Box to be updated over time.