### PR TITLE
Updated RCASD Years on Real Prop macro

### DIFF
--- a/Macros/Update_real_property.sas
+++ b/Macros/Update_real_property.sas
@@ -193,7 +193,9 @@
     
     set 
       Dhcd.Rcasd_2015
-      Dhcd.Rcasd_2016;
+      Dhcd.Rcasd_2016
+	  Dhcd.Rcasd_2017
+	  Dhcd.Rcasd_2018;
     by nidc_rcasd_id;
     
     where put( ssl, $sslsel. ) ~= "";


### PR DESCRIPTION
@ptatian @woliver01 Hey Peter, Will was having an issue with the real prop report. It just wasn't opening because there were no records within 90 days.

In looking into that however, I realized that the update_real_property.sas macro only called in RCASD data from 2015 and 2016. I figured it was just a oversight, and added the last two years. This doesn't need your review unless there was some specific reason those years were left off the macro.