### PR TITLE
Update #326

### DIFF
--- a/Prog/Updates/Update_MFIS_2022_10.sas
+++ b/Prog/Updates/Update_MFIS_2022_10.sas
@@ -1,0 +1,26 @@
+/**************************************************************************
+ Program:  Update_MFIS_2022_10.sas
+ Library:  PresCat
+ Project:  Urban-Greater DC
+ Author:   Donovan Harvey
+ Created:  12/7/22
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ GitHub issue: #326 
+ 
+ Description:  Update Preservation Catalog with latest 
+ HUD MFIS update file.
+
+ Modifications:
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( PresCat )
+%DCData_lib( HUD )
+
+
+%Update_MFIS( Update_file=MFIS_2022_10 )
+
+

--- a/Prog/Updates/Update_REAC_2022_10.sas
+++ b/Prog/Updates/Update_REAC_2022_10.sas
@@ -1,0 +1,25 @@
+/**************************************************************************
+ Program:  Update_REAC_2022_10.sas
+ Library:  PresCat
+ Project:  Urban-Greater DC
+ Author:   Donovan Harvey
+ Created:  12/7/2022
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ GitHub issue:  #326
+ 
+ Description:  Update Preservation Catalog with latest HUD REAC scores.
+
+ Modifications:
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( PresCat )
+%DCData_lib( HUD )
+
+
+%Update_REAC( Update_file=REAC_2022_10 )
+
+

--- a/Prog/Updates/Update_Sec8mf_20222_10.sas
+++ b/Prog/Updates/Update_Sec8mf_20222_10.sas
@@ -1,0 +1,25 @@
+/**************************************************************************
+ Program:  Update_Sec8mf_2022_10.sas
+ Library:  PresCat
+ Project:  Urban-Greater DC
+ Author:   Donovan Harvey
+ Created:  12/05/2022
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ GitHub issue:  #326
+ 
+ Description:  Update Preservation Catalog with latest HUD Sec 8 MF
+ update file.
+
+ Modifications:
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( PresCat )
+%DCData_lib( HUD )
+
+options nominoperator;
+%Update_Sec8mf( Update_file=Sec8mf_2022_10 )
+


### PR DESCRIPTION
@ptatian Requesting review on the MFIS, SEC8MF and REAC updates. The REAC and Sec8 updates looked fine but it looks like something is going wrong with the MFIS update.
1. Developments that are in the catalog (Samuel Kelsey, Kenyon) appear in the non-match file and,
2. In the subsidy file, the previous old value is now appearing in the "exception" column (see below)
![image](https://user-images.githubusercontent.com/96495845/206279558-c5de90e4-23a1-489a-8ace-7fd2e353dacc.pn
[2022_10 MFISLOG.log](https://github.com/NeighborhoodInfoDC/PresCat/files/10179461/2022_10.MFISLOG.log)
g)
[Update_MFIS_2022_10_subsidy_nonmatch.xls](https://github.com/NeighborhoodInfoDC/PresCat/files/10179453/Update_MFIS_2022_10_subsidy_nonmatch.xls)
