### PR TITLE
add year built to TOPA_ssl data set

### DIFF
--- a/Prog/TOPA/TOPA_data_to_DC_data.sas
+++ b/Prog/TOPA/TOPA_data_to_DC_data.sas
@@ -161,6 +161,11 @@ proc sql noprint;
   order by TOPA_geocoded.ID, Xref.ssl;    /** Optional: sorts the output data set **/
 quit;
 
+** Remove duplicate SSLs **;
+proc sort data=TOPA_SSL nodupkey;
+  by id ssl;
+run;
+
 %File_info( data=TOPA_SSL, printobs=5 )
 
 %File_info( data=RealProp.Sales_master, printobs=5 )

--- a/Prog/TOPA/TOPA_data_to_DC_data.sas
+++ b/Prog/TOPA/TOPA_data_to_DC_data.sas
@@ -20,7 +20,7 @@
 %DCData_lib( MAR )
 %DCData_lib( RealProp )
 
-%let revisions = Add u_date_dhcd_received_ta_reg.;
+%let revisions = Add u_date_dhcd_received_ta_reg. add AYB. and EYB. to Topa_ssl;
 
 ** Download and read TOPA dataset into SAS dataset**;
 %let dsname="&_dcdata_r_path\PresCat\Raw\TOPA\TOPA-DOPA 5+_with_var_names_3_20_23_urban_update.csv";

--- a/Prog/TOPA/TOPA_data_to_DC_data.sas
+++ b/Prog/TOPA/TOPA_data_to_DC_data.sas
@@ -362,10 +362,6 @@ proc sort data=TOPA_SSL out=ssl_sorted;
   by ssl;
 run;
 
-proc sort data=Realprop.cama_parcel;
-  by ssl;
-run;
-
 data Topa_ssl_parcel; 
   merge
    Realprop.cama_parcel (keep=ssl AYB EYB)

--- a/Prog/TOPA/TOPA_data_to_DC_data.sas
+++ b/Prog/TOPA/TOPA_data_to_DC_data.sas
@@ -350,6 +350,26 @@ data Topa_database;
   
 run;
 
+*************************************************************************
+** Adding year built (originally and after recent reno) to TOPA_SSL database **;
+
+proc sort data=TOPA_SSL out=ssl_sorted;
+  by ssl;
+run;
+
+proc sort data=Realprop.cama_parcel;
+  by ssl;
+run;
+
+data Topa_ssl_parcel; 
+  merge
+   Realprop.cama_parcel (keep=ssl AYB EYB)
+   ssl_sorted;
+  by ssl; 
+  if missing( id ) then delete;
+run; 
+
+%File_info( data=Topa_ssl_parcel, printobs=5 ) /** 4635 obs**/
 
 *************************************************************************
 ** Export 2007 TOPA/real property data **;
@@ -507,7 +527,7 @@ ods listing;   /** Reopen the listing destination **/
 
   %Finalize_data_set( 
     /** Finalize data set parameters **/
-    data=Topa_ssl,
+    data=Topa_ssl_parcel,
     out=Topa_ssl,
     outlib=PresCat,
     label="Preservation Catalog, real property parcels for TOPA database properties",

--- a/Prog/TOPA/TOPA_data_to_DC_data.sas
+++ b/Prog/TOPA/TOPA_data_to_DC_data.sas
@@ -20,7 +20,7 @@
 %DCData_lib( MAR )
 %DCData_lib( RealProp )
 
-%let revisions = Add u_date_dhcd_received_ta_reg. add AYB. and EYB. to Topa_ssl;
+%let revisions = Add AYB. and EYB. to Topa_ssl;
 
 ** Download and read TOPA dataset into SAS dataset**;
 %let dsname="&_dcdata_r_path\PresCat\Raw\TOPA\TOPA-DOPA 5+_with_var_names_3_20_23_urban_update.csv";


### PR DESCRIPTION
@ptatian I decided it was best to add the year built vars to the TOPA_ssl dataset that we created in the first prog as I couldn't match the cama_parcel dataset to the TOPA_database because the TOPA_database has multiple SSLs. I'm doing the # of units and ward in the match_notice prog but need this one to batch submit before I finish that prog up to incorpoate the years built. 