### PR TITLE
Make_formats.sas and the name-clean macros run unmodified on Jenner

### DIFF
--- a/jenner-check/.gitignore
+++ b/jenner-check/.gitignore
@@ -1,0 +1,2 @@
+*_response.json
+response.json

--- a/jenner-check/README.md
+++ b/jenner-check/README.md
@@ -1,0 +1,76 @@
+# jenner-check: compatibility test bundles
+
+Each `tNNN_<slug>/` subdirectory is a self-contained test bundle built from SAS
+code that already lives in this repository. A bundle pins the output of a
+captured passing run so the same script can be re-run later and compared
+against that snapshot.
+
+This directory is fully self-contained: nothing outside `jenner-check/` is
+referenced or modified, nothing runs on merge or checkout, and deleting the
+directory removes every trace of it.
+
+## What the runner sends — read before running
+
+`run_jenner.sh` uploads only a bundle's SAS **source text** — `autoexec.sas`
+plus `script.sas`, and nothing else — over HTTPS to `api.jenneranalytics.com`,
+where it runs and returns the log and listing. It does not read or upload any
+data files, so anything sitting next to a script stays on your machine; the
+only thing transmitted is the code you run, as when pasting a snippet into any
+hosted tool. Nothing is sent unless you run a command yourself. To point the
+runner at a different endpoint, set `JENNER_HOST`.
+
+## What's in here
+
+```
+jenner-check/
+├── README.md            # this file
+├── run_jenner.sh        # runner (bash + curl; python3 used if present)
+└── tNNN_<slug>/
+    ├── script.sas       # the SAS under test (derived from this repo)
+    ├── autoexec.sas     # run options prepended to script.sas at run time
+    ├── expected.json    # fields pinned from the captured passing run
+    ├── meta.json        # provenance: source file, blob sha, commit
+    └── expected/        # human-readable snapshot of that run
+        ├── log.txt
+        └── output.txt
+```
+
+`meta.json` records the source path, blob sha, and commit of the script each
+bundle was built from, so you can verify the copy matches your code.
+
+## How to run
+
+From inside this directory:
+
+```bash
+./run_jenner.sh --list             # show the bundles in this directory
+./run_jenner.sh --all              # run every bundle, verify pinned fields
+./run_jenner.sh tNNN_<slug>        # run just one (use a name from --list)
+```
+
+For each bundle the runner submits the SAS, writes the JSON response to
+`<bundle>_response.json`, and compares the response against the bundle's
+`expected.json` — status, exit code, and the pinned log lines. A bundle
+passes only when every pinned field matches, so an `N pass, 0 fail` summary
+from `--all` means the captured results still hold.
+
+You can also compare a saved response offline, with no network call:
+
+```bash
+./run_jenner.sh --compare tNNN_<slug>_response.json tNNN_<slug>/expected.json
+```
+
+Requirements: `bash` 4+ and `curl` (both ship with mainstream Linux and
+macOS); `python3` for the pinned-field comparison. On Windows, run it under
+WSL.
+
+## Removing this directory
+
+`git rm -r jenner-check/` (or just delete the folder). Nothing else in the
+repository references it.
+
+---
+
+`run_jenner.sh` and this README are provided under the MIT license. Each
+bundle's `script.sas` is a copy of code that already lives in this repository
+and remains under this repository's own license — nothing here relicenses it.

--- a/jenner-check/run_jenner.sh
+++ b/jenner-check/run_jenner.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# run_jenner.sh - mac/linux runner for Jenner compatibility checks.
+#
+# Quick start:
+#   cd jenner-check/
+#   ./run_jenner.sh                  # lists bundles in the current dir
+#   ./run_jenner.sh t001_something   # run that one
+#   ./run_jenner.sh --all            # run every bundle in the current dir
+#
+# Usage:   ./run_jenner.sh [bundle-dir | script.sas | --all | --list] [response.json]
+#          ./run_jenner.sh --compare RESPONSE.json EXPECTED.json
+#
+#   (no arg)     If the current directory has tNNN_* bundles, list them
+#                with a copy-paste command. Otherwise show this help.
+#
+#   --all        Run every tNNN_* bundle in the current directory in
+#                sequence, print a pass/fail summary.
+#
+#   --list, -l   List the bundles visible in the current directory and
+#                exit without running anything.
+#
+#   --compare    Purely local, no network: check RESPONSE.json against the
+#                pinned EXPECTED.json and print one line per check. Only
+#                keys present in EXPECTED.json are checked (keys starting
+#                with "_" are provenance and ignored): status / exit_code
+#                must match exactly, every log_contains entry must appear
+#                in the response log, no log_does_not_contain entry may
+#                appear, output_contains entries must appear in the output,
+#                and pinned diagnostics lists must match exactly. Unknown
+#                keys print a warning and do not fail.
+#                Exit 0 all-match, 1 any mismatch, 2 usage/unreadable file/
+#                invalid JSON, 5 python3 unavailable.
+#
+#   bundle-dir   A directory containing script.sas and (optionally)
+#                autoexec.sas. The two are concatenated (autoexec first,
+#                then a blank line, then script) and submitted together.
+#                This is the normal case.
+#
+#   script.sas   A single .sas file. Submitted as-is — no autoexec.
+#
+# The API response is written to <response.json> (or response.json in
+# the current directory if omitted) and the most useful fields are also
+# printed to stdout for a quick sanity check.
+#
+# What "pass" means: a bundle run passes only if the POST returns HTTP 200
+# AND — when the bundle carries an expected.json and python3 is available —
+# the fresh response matches every pinned field (the --compare semantics
+# above). Without python3 the pinned comparison is skipped with a notice
+# and the run falls back to the old HTTP/status-only behavior.
+#
+# Requires: bash 4+, curl. Both ship with every mainstream Linux distro
+# and macOS 12+. python3 (present on virtually every modern system) is
+# optional but needed for the pinned-result comparison and the pretty
+# summary. Windows: use run_jenner.bat (single-file mode) or WSL.
+#
+# IMPORTANT: execute this script, don't source it. Running with `. ./...`
+# or `source ./...` will short-circuit error handling and can close your
+# terminal if an error path fires.
+
+# --- refuse to be sourced ------------------------------------------------
+# `return` only works inside a sourced script. If we ARE sourced, print a
+# message and return 1 so we don't kill the parent shell with exit. If
+# we're running directly, (return 0) fails and we fall through.
+(return 0 2>/dev/null) && {
+  printf 'run_jenner.sh: execute this script, do not source it.\n  ./run_jenner.sh <bundle-dir-or-script.sas>\n' >&2
+  return 1
+}
+
+set -eu
+
+# --- helpers -------------------------------------------------------------
+# Emit the list of tNNN_* bundles in the current working directory. A
+# "bundle" is a directory matching t[0-9]*_* whose name contains a
+# script.sas file. Writes one path per line (no prefix); empty output
+# if nothing found.
+list_bundles_here() {
+  local d
+  for d in ./t[0-9]*_*/ ; do
+    [[ -d "$d" && -f "$d/script.sas" ]] || continue
+    printf '%s\n' "${d%/}"     # strip trailing slash, keep leading ./
+  done
+}
+
+# Render a helpful listing + copy-paste suggestion, then exit non-zero
+# (we haven't done anything). Used when the user runs with no args.
+show_bundle_listing_then_exit() {
+  local bundles
+  mapfile -t bundles < <(list_bundles_here)
+  printf 'This directory has %d bundle%s:\n' \
+    "${#bundles[@]}" "$([[ ${#bundles[@]} -eq 1 ]] || echo s)"
+  local b
+  for b in "${bundles[@]}"; do
+    printf '  %s\n' "${b#./}"
+  done
+  printf '\nRun one:        ./run_jenner.sh %s\n' "${bundles[0]#./}"
+  printf 'Run them all:   ./run_jenner.sh --all\n'
+  printf 'Just list:      ./run_jenner.sh --list\n'
+  exit 2
+}
+
+# Show the usage block when we have nothing better to offer.
+show_usage_then_exit() {
+  local status=${1:-2}
+  {
+    printf 'Usage: %s [bundle-dir | script.sas | --all | --list] [response.json]\n' "$(basename "$0")"
+    printf '       %s --compare RESPONSE.json EXPECTED.json\n\n' "$(basename "$0")"
+    printf 'Examples:\n'
+    printf '  %s t001_my_bundle         # run one bundle\n' "$(basename "$0")"
+    printf '  %s --all                  # run every tNNN_* bundle in this dir\n' "$(basename "$0")"
+    printf '  %s path/to/script.sas     # run a single file, no autoexec\n' "$(basename "$0")"
+    printf '  %s --compare r.json e.json # check a response against pinned fields\n' "$(basename "$0")"
+  } >&2
+  exit "$status"
+}
+
+# Compare a response.json against a pinned expected.json. Purely local —
+# no network. Only keys present in expected.json are checked; keys whose
+# name starts with "_" are capture provenance and are ignored. Prints one
+# line per check (ok/FAIL/warn). Return codes: 0 all checks match,
+# 1 any mismatch, 2 unreadable file or invalid JSON, 5 python3 missing.
+compare_response_to_expected() {
+  local resp_file=$1 expected_file=$2
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf 'error: the pinned comparison needs python3, which was not found\n' >&2
+    return 5
+  fi
+  python3 - "$resp_file" "$expected_file" <<'PY'
+import json, sys
+
+def load(path, label):
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError) as e:
+        print(f"compare: cannot read {label} file {path}: {e}", file=sys.stderr)
+        sys.exit(2)
+
+resp = load(sys.argv[1], "response")
+exp = load(sys.argv[2], "expected")
+if not isinstance(resp, dict) or not isinstance(exp, dict):
+    print("compare: both files must contain a JSON object", file=sys.stderr)
+    sys.exit(2)
+
+failures = 0
+
+def ok(msg):
+    print(f"  ok    {msg}")
+
+def bad(msg):
+    global failures
+    failures += 1
+    print(f"  FAIL  {msg}")
+
+def as_list(v):
+    return v if isinstance(v, list) else [v]
+
+log = resp.get("log") or ""
+output = resp.get("output") or ""
+
+for key, want in exp.items():
+    if key.startswith("_"):
+        continue                      # provenance (_captured_at, ...), not a check
+    if key in ("status", "exit_code"):
+        got = resp.get(key)
+        if got == want:
+            ok(f"{key} == {want!r}")
+        else:
+            bad(f"{key}: expected {want!r}, got {got!r}")
+    elif key == "log_contains":
+        for s in as_list(want):
+            if s in log:
+                ok(f"log contains {s!r}")
+            else:
+                bad(f"log_contains: log is missing {s!r}")
+    elif key == "log_does_not_contain":
+        for s in as_list(want):
+            if s not in log:
+                ok(f"log does not contain {s!r}")
+            else:
+                bad(f"log_does_not_contain: log unexpectedly contains {s!r}")
+    elif key == "output_contains":
+        for s in as_list(want):
+            if s in output:
+                ok(f"output contains {s!r}")
+            else:
+                bad(f"output_contains: output is missing {s!r}")
+    elif key == "diagnostics":
+        diag = resp.get("diagnostics") or {}
+        for dk, dv in (want or {}).items():
+            if dk.startswith("_"):
+                continue
+            got = diag.get(dk)
+            if got == dv:
+                ok(f"diagnostics.{dk} == {dv!r}")
+            else:
+                bad(f"diagnostics.{dk}: expected {dv!r}, got {got!r}")
+    else:
+        print(f"  warn  unknown expected.json key {key!r} — not checked")
+
+if failures:
+    print(f"pinned comparison: {failures} check(s) FAILED")
+    sys.exit(1)
+print("pinned comparison: all pinned checks passed")
+PY
+}
+
+# --- arg parsing ---------------------------------------------------------
+if [[ $# -lt 1 ]]; then
+  # No args: if the cwd contains bundles, list them; otherwise show help.
+  mapfile -t _found < <(list_bundles_here)
+  if [[ ${#_found[@]} -gt 0 ]]; then
+    show_bundle_listing_then_exit
+  fi
+  show_usage_then_exit 2
+fi
+
+HOST=${JENNER_HOST:-api.jenneranalytics.com}
+
+case "$1" in
+  -h|--help)
+    show_usage_then_exit 0
+    ;;
+  -l|--list)
+    mapfile -t _found < <(list_bundles_here)
+    if [[ ${#_found[@]} -eq 0 ]]; then
+      printf 'No tNNN_* bundles found in %s\n' "$(pwd)"
+      exit 0
+    fi
+    printf 'Bundles in %s:\n' "$(pwd)"
+    for b in "${_found[@]}"; do
+      printf '  %s\n' "${b#./}"
+    done
+    exit 0
+    ;;
+  --compare)
+    # Purely local: diff a response.json against a pinned expected.json.
+    if [[ $# -ne 3 ]]; then
+      printf 'usage: %s --compare RESPONSE.json EXPECTED.json\n' "$(basename "$0")" >&2
+      exit 2
+    fi
+    _rc=0
+    compare_response_to_expected "$2" "$3" || _rc=$?
+    exit "$_rc"
+    ;;
+  --all)
+    mapfile -t _found < <(list_bundles_here)
+    if [[ ${#_found[@]} -eq 0 ]]; then
+      printf 'No tNNN_* bundles found in %s\n' "$(pwd)" >&2
+      exit 3
+    fi
+    _pass=0; _fail=0
+    for b in "${_found[@]}"; do
+      printf '\n── %s ──\n' "${b#./}"
+      if "$0" "$b" "${b#./}_response.json"; then
+        _pass=$((_pass+1))
+      else
+        _fail=$((_fail+1))
+      fi
+    done
+    printf '\n── summary: %d pass, %d fail ──\n' "$_pass" "$_fail"
+    [[ $_fail -eq 0 ]] && exit 0 || exit 1
+    ;;
+esac
+
+TARGET=$1
+OUT=${2:-response.json}
+
+# --- assemble the submission body ---------------------------------------
+# If TARGET is a directory, treat it as a bundle. If it's a file, submit
+# it directly.
+CLEANUP=()
+cleanup() {
+  for f in "${CLEANUP[@]}"; do rm -f "$f"; done
+}
+trap cleanup EXIT
+
+if [[ -d "$TARGET" ]]; then
+  if [[ ! -f "$TARGET/script.sas" ]]; then
+    printf 'error: %s is a directory but has no script.sas\n' "$TARGET" >&2
+    exit 3
+  fi
+  SUBMIT=$(mktemp -t jc_submit.XXXXXX.sas)
+  CLEANUP+=("$SUBMIT")
+  if [[ -f "$TARGET/autoexec.sas" ]]; then
+    cat "$TARGET/autoexec.sas" > "$SUBMIT"
+    printf '\n' >> "$SUBMIT"
+  fi
+  cat "$TARGET/script.sas" >> "$SUBMIT"
+  printf 'Submitting bundle: %s\n' "$TARGET"
+  if [[ -f "$TARGET/autoexec.sas" ]]; then
+    printf '  autoexec.sas (%d bytes) + script.sas (%d bytes)\n' \
+      "$(wc -c < "$TARGET/autoexec.sas")" "$(wc -c < "$TARGET/script.sas")"
+  else
+    printf '  script.sas (%d bytes), no autoexec\n' "$(wc -c < "$TARGET/script.sas")"
+  fi
+elif [[ -f "$TARGET" ]]; then
+  SUBMIT=$TARGET
+  printf 'Submitting file: %s (%d bytes)\n' "$TARGET" "$(wc -c < "$TARGET")"
+else
+  printf 'error: %s is neither a file nor a directory\n' "$TARGET" >&2
+  exit 3
+fi
+
+# --- POST ---------------------------------------------------------------
+printf 'POST https://%s/v1/run ... ' "$HOST"
+HTTP_CODE=$(curl -sS -o "$OUT" -w '%{http_code}' -X POST \
+  "https://${HOST}/v1/run" \
+  -F "script=@${SUBMIT};type=application/x-sas" \
+  -F "deterministic=1" \
+  -F "timeout=60")
+printf 'HTTP %s\n' "$HTTP_CODE"
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+  printf 'API returned non-200 — raw response in %s\n' "$OUT" >&2
+  exit 4
+fi
+
+# --- summarise ----------------------------------------------------------
+# Best-effort: use python if present, otherwise grep key fields.
+printf 'Response written to %s\n' "$OUT"
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$OUT" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+print(f"  status     : {r.get('status')}")
+print(f"  exit_code  : {r.get('exit_code')}")
+print(f"  duration_ms: {r.get('duration_ms')}")
+print(f"  run_id     : {r.get('run_id')}")
+print(f"  jenner_ver : {r.get('jenner_version')}")
+log = r.get('log', '')
+if log:
+    print('  log (first 10 lines):')
+    for line in log.splitlines()[:10]:
+        print(f'    {line}')
+PY
+else
+  printf '  (install python3 for a pretty summary; raw JSON in %s)\n' "$OUT"
+fi
+
+# --- pinned-result comparison ---------------------------------------------
+# A bundle that ships an expected.json only passes if the fresh response
+# matches every pinned field — HTTP 200 alone is not a pass. Without
+# python3 we can't parse JSON portably, so fall back to the old behavior
+# and say so.
+if [[ -d "$TARGET" && -f "$TARGET/expected.json" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    printf 'Comparing response against pinned %s/expected.json\n' "${TARGET%/}"
+    _rc=0
+    compare_response_to_expected "$OUT" "$TARGET/expected.json" || _rc=$?
+    if [[ $_rc -ne 0 ]]; then
+      printf 'Bundle FAILED the pinned comparison (see lines above)\n' >&2
+      exit "$_rc"
+    fi
+  else
+    printf 'pinned comparison skipped (python3 not found) — HTTP/status only\n'
+  fi
+fi

--- a/jenner-check/t001_project_name_clean/autoexec.sas
+++ b/jenner-check/t001_project_name_clean/autoexec.sas
@@ -1,0 +1,45 @@
+/* cap input rows for the captured run */
+options obs=100;
+
+/* The following %macro is copied verbatim from Macros/Project_name_clean.sas
+   in this repo, so the caller in script.sas exercises the repo's own macro. */
+
+/** Macro Project_name_clean - Start Definition **/
+
+%macro Project_name_clean( source, target );
+
+  &target = propcase( left( compbl( &source ) ) );
+
+  &target = tranwrd( &target, 'Iii', 'III' );
+  &target = tranwrd( &target, 'Ii', 'II' );
+  &target = tranwrd( &target, 'Iv', 'IV' );
+  &target = tranwrd( &target, 'IVy', 'Ivy' );
+  &target = tranwrd( &target, 'Ne', 'NE' );
+  &target = tranwrd( &target, 'NEw', 'New' );
+  &target = tranwrd( &target, 'NEighborhood', 'Neighborhood' );
+  &target = tranwrd( &target, 'NEighbors', 'Neighbors' );
+  &target = tranwrd( &target, 'NEhemiah', 'Nehemiah' );
+  &target = tranwrd( &target, 'Nw', 'NW' );
+  &target = tranwrd( &target, 'Se', 'SE' );
+  &target = tranwrd( &target, 'SEnior', 'Senior' );
+  &target = tranwrd( &target, 'SEcond', 'Second' );
+  &target = tranwrd( &target, 'SErvices', 'Services' );
+  &target = tranwrd( &target, 'SEnate', 'Senate' );
+  &target = tranwrd( &target, 'Sw', 'SW' );
+  &target = tranwrd( &target, 'At', 'at' );
+  &target = tranwrd( &target, 'atlantic', 'Atlantic' );
+
+  &target = tranwrd( &target, 'Pud', 'PUD' );
+  &target = tranwrd( &target, 'Chhi', 'CHHI' );
+  &target = tranwrd( &target, 'Ncba', 'NCBA' );
+  &target = tranwrd( &target, 'Cemi', 'CEMI' );
+  &target = tranwrd( &target, 'Idi', 'IDI' );
+  &target = tranwrd( &target, 'Wdc', 'WDC' );
+  &target = tranwrd( &target, 'Mlk', 'MLK' );
+  &target = tranwrd( &target, 'Ufas', 'UFAS' );
+  &target = tranwrd( &target, 'Dmh', 'DMH' );
+  &target = tranwrd( &target, 'Tcb', 'TCB' );
+
+%mend Project_name_clean;
+
+/** End Macro Definition **/

--- a/jenner-check/t001_project_name_clean/expected.json
+++ b/jenner-check/t001_project_name_clean/expected.json
@@ -1,0 +1,12 @@
+{
+  "_captured_at": "2026-07-09T08:24:00Z",
+  "_captured_run_id": "r_89a13613fe0b40a1bce9581578ef1fc1",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: Wrote cleaned (8 rows, 2 columns).",
+    "NOTE: PROC PRINT completed: 8 observations printed, 2 variables"
+  ],
+  "log_does_not_contain": ["ERROR:", "[JENNER-ERROR"],
+  "diagnostics": {"parse_warnings": [], "runtime_warnings": []}
+}

--- a/jenner-check/t001_project_name_clean/expected/log.txt
+++ b/jenner-check/t001_project_name_clean/expected/log.txt
@@ -1,0 +1,21 @@
+NOTE: Option OBS changed to 100.
+NOTE: DATA raw_names
+
+NOTE: Processing inline DATALINES (8 lines)
+
+NOTE: Read 8 rows from DATALINES.
+NOTE: Wrote raw_names (8 rows, 1 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: DATA cleaned
+
+
+NOTE: Read 8 rows from raw_names.
+NOTE: Wrote cleaned (8 rows, 2 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=cleaned
+
+NOTE: PROC PRINT completed: 8 observations printed, 2 variables

--- a/jenner-check/t001_project_name_clean/expected/output.txt
+++ b/jenner-check/t001_project_name_clean/expected/output.txt
@@ -1,0 +1,10 @@
+Raw project name            Cleaned project name
+------------------------------  ------------------------------
+IVY CITY SENIOR RESIDENCES III  Ivy City Senior Residences III
+brookland manor ne              Brookland Manor NE
+2ND STREET PUD                  2nd Street PUD
+neighborhood NCBA towers        Neighborhood NCBA Towers
+MLK gateway se                  MLK Gateway SE
+the villages at ivy iv          The Villages at Ivy IV
+CHHI senate square sw           CHHI Senate Square SW
+NEW BEGINNINGS second nw        New Beginnings Second NW

--- a/jenner-check/t001_project_name_clean/meta.json
+++ b/jenner-check/t001_project_name_clean/meta.json
@@ -1,0 +1,7 @@
+{
+  "bundle": "t001_project_name_clean",
+  "source_file": "Macros/Project_name_clean.sas",
+  "source_blob_sha": "0f3e7c9f12a89f59e272847244ac08d4d80a1bbc",
+  "source_commit": "ee29c6748c510be6af4c4b1180f0397a299a2f81",
+  "notes": "Repo autocall macro %Project_name_clean copied verbatim into autoexec.sas; script.sas is a caller that runs 8 raw DC housing project names through it and PROC PRINTs raw vs cleaned. No external deps (pure propcase/compbl/tranwrd), so no data substitution needed - only inline sample names added."
+}

--- a/jenner-check/t001_project_name_clean/script.sas
+++ b/jenner-check/t001_project_name_clean/script.sas
@@ -1,0 +1,34 @@
+/**************************************************************************
+ Caller for the repo's %Project_name_clean autocall macro
+ (Macros/Project_name_clean.sas). The macro rewrites a raw project name
+ into title case and then fixes the abbreviations and Roman numerals that
+ propcase() would otherwise mangle (NE/NW/SE/SW quadrants, III/II/IV,
+ PUD, CHHI, NCBA, ...). Here we run a handful of raw names through it and
+ print the before/after so the substitutions are visible.
+**************************************************************************/
+
+data raw_names;
+  length raw_name $ 60;
+  input raw_name $char60.;
+  datalines;
+IVY CITY SENIOR RESIDENCES III
+brookland manor ne
+2ND STREET PUD
+neighborhood NCBA towers
+MLK gateway se
+the villages at ivy iv
+CHHI senate square sw
+NEW BEGINNINGS second nw
+;
+run;
+
+data cleaned;
+  set raw_names;
+  length clean_name $ 60;
+  %Project_name_clean( raw_name, clean_name )
+run;
+
+proc print data=cleaned noobs label;
+  var raw_name clean_name;
+  label raw_name = "Raw project name" clean_name = "Cleaned project name";
+run;

--- a/jenner-check/t002_make_formats/autoexec.sas
+++ b/jenner-check/t002_make_formats/autoexec.sas
@@ -1,0 +1,2 @@
+/* cap input rows for the captured run */
+options obs=100;

--- a/jenner-check/t002_make_formats/expected.json
+++ b/jenner-check/t002_make_formats/expected.json
@@ -1,0 +1,13 @@
+{
+  "_captured_at": "2026-07-09T08:25:00Z",
+  "_captured_run_id": "r_94cda109b9944f64944446cd0071966c",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: FORMAT $Categry defined (7 ranges).",
+    "NOTE: FORMAT $ownmgrtype defined (7 ranges).",
+    "NOTE: PROC PRINT completed: 5 observations printed, 5 variables"
+  ],
+  "log_does_not_contain": ["ERROR:", "[JENNER-ERROR"],
+  "diagnostics": {"parse_warnings": [], "runtime_warnings": []}
+}

--- a/jenner-check/t002_make_formats/expected/log.txt
+++ b/jenner-check/t002_make_formats/expected/log.txt
@@ -1,0 +1,20 @@
+NOTE: Option OBS changed to 100.
+NOTE: PROC FORMAT library=WORK
+
+NOTE: FORMAT $Status defined (2 ranges).
+NOTE: FORMAT $Categry defined (7 ranges).
+NOTE: FORMAT $Infosrc defined (5 ranges).
+NOTE: FORMAT $rptype defined (4 ranges).
+NOTE: FORMAT $ownmgrtype defined (7 ranges).
+NOTE: DATA catalog
+
+NOTE: Processing inline DATALINES (5 lines)
+
+NOTE: Read 5 rows from DATALINES.
+NOTE: Wrote catalog (5 rows, 5 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=catalog
+
+NOTE: PROC PRINT completed: 5 observations printed, 5 variables

--- a/jenner-check/t002_make_formats/expected/output.txt
+++ b/jenner-check/t002_make_formats/expected/output.txt
@@ -1,0 +1,7 @@
+Project ID    Status                          Category                                  Information source        Owner/manager type
+----------  --------  --------------------------------  --------------------------------------------------  ------------------------
+NL000046    Active    At-Risk or Flagged for Follow-up  HUD/Multifamily Assistance and Section 8 Contracts  Non-profit
+NL000093    Active    Expiring Subsidy                  HUD/Low Income Housing Tax Credits                  Profit motivated
+NL000319    Inactive  Lost Rental                       HUD/Picture of Subsidized Households                Public housing authority
+NL001007    Active    Recent Failing REAC Score         HUD/Insured Multifamily Mortgages                   Non-profit controlled
+NL001030    Active    Other Subsidized Property         VCU-CNHED/Limited equity cooperative database       Individual

--- a/jenner-check/t002_make_formats/meta.json
+++ b/jenner-check/t002_make_formats/meta.json
@@ -1,0 +1,7 @@
+{
+  "bundle": "t002_make_formats",
+  "source_file": "Prog/Make_formats.sas",
+  "source_blob_sha": "c5abbad3ce664b23bff8a5d02817b1e3bddfdb9c",
+  "source_commit": "ee29c6748c510be6af4c4b1180f0397a299a2f81",
+  "notes": "Subset of the repo's Make_formats.sas: value blocks $Status, $Categry, $Infosrc, $rptype, $ownmgrtype copied verbatim. Two substitutions to make it self-contained: removed the leading %include of StdLocal.sas and the %DCData_lib(PresCat) call, and changed 'library=PresCat' to 'library=work'. Added a small caller that PROC PRINTs 5 catalog-shaped records with the formats applied. Full program has 20 value blocks; a representative 5 were kept for a focused, readable bundle."
+}

--- a/jenner-check/t002_make_formats/script.sas
+++ b/jenner-check/t002_make_formats/script.sas
@@ -1,0 +1,68 @@
+/**************************************************************************
+ A subset of Prog/Make_formats.sas from this repo. The value blocks below
+ ($Status, $Categry, $Infosrc, $rptype, $ownmgrtype) are copied verbatim
+ from that program; only two lines were changed so the bundle is
+ self-contained: the leading %include of StdLocal.sas and the
+ %DCData_lib( PresCat ) call are removed, and the format catalog is written
+ to WORK instead of the PresCat library. A short caller then applies the
+ formats to a handful of catalog records so the mappings are visible.
+**************************************************************************/
+
+proc format library=work;
+
+  value $Status
+    "A" = "Active"
+    "I" = "Inactive";
+
+  value $Categry
+    "1" = "At-Risk or Flagged for Follow-up"
+    "2" = "Expiring Subsidy"
+    "3" = "Recent Failing REAC Score"
+    "4" = "More Info Needed"
+    "5" = "Other Subsidized Property"
+    "6" = "Lost Rental"
+    "7" = "Replaced";
+
+  value $Infosrc
+    "HUD/MFA" = "HUD/Multifamily Assistance and Section 8 Contracts"
+    "HUD/MFIS" = "HUD/Insured Multifamily Mortgages"
+    "HUD/LIHTC" = "HUD/Low Income Housing Tax Credits"
+    "HUD/PSH" = "HUD/Picture of Subsidized Households"
+    "VCU-CNHED/LECOOP" = "VCU-CNHED/Limited equity cooperative database";
+
+  value $rptype
+    "OTR/SALE" = "OTR: Property sale"
+    "ROD/FCLNOT" = "ROD: Foreclosure notice"
+    "NIDC/FCLOUT" = "NIDC: Foreclosure outcome"
+    "DHCD/RCASD" = "DHCD: RCASD notice";
+
+  value $ownmgrtype
+    "LD" = "Limited dividend"
+    "NP" = "Non-profit"
+    "NC" = "Non-profit controlled"
+    "OT" = "Other"
+    "HA" = "Public housing authority"
+    "PM" = "Profit motivated"
+    "IN" = "Individual";
+
+run;
+
+/* Apply the formats to a small set of catalog-shaped records. */
+data catalog;
+  length nlihc_id $ 16 status $ 1 category $ 1 info_source $ 20 owner_type $ 2;
+  input nlihc_id $ status $ category $ info_source $ owner_type $;
+  datalines;
+NL000046 A 1 HUD/MFA NP
+NL000093 A 2 HUD/LIHTC PM
+NL000319 I 6 HUD/PSH HA
+NL001007 A 3 HUD/MFIS NC
+NL001030 A 5 VCU-CNHED/LECOOP IN
+;
+run;
+
+proc print data=catalog noobs label;
+  var nlihc_id status category info_source owner_type;
+  format status $Status. category $Categry. info_source $Infosrc. owner_type $ownmgrtype.;
+  label nlihc_id = "Project ID" status = "Status" category = "Category"
+        info_source = "Information source" owner_type = "Owner/manager type";
+run;

--- a/jenner-check/t003_update_rpt_write_var/autoexec.sas
+++ b/jenner-check/t003_update_rpt_write_var/autoexec.sas
@@ -1,0 +1,55 @@
+/* cap input rows for the captured run */
+options obs=100;
+
+/* The following %macro is copied verbatim from Macros/Update_rpt_write_var.sas
+   in this repo. It emits the assignment/output statements that build one row
+   of a catalog "update report" for a single variable, comparing the base
+   value against the compare value and any exception override. The caller in
+   script.sas invokes it once per variable inside a DATA step. */
+
+/** Macro Update_rpt_write_var - Start Definition **/
+
+%macro Update_rpt_write_var( var=, fmt=comma8.0, lbl=, typ=n, except=y );
+
+  %if &lbl = %then %do;
+    Var = "&var";
+  %end;
+  %else %do;
+    Var = &lbl;
+  %end;
+
+  Old_value = put( &var._Base, &fmt );
+
+  %if %upcase( &typ ) = N %then %do;
+
+    if missing( &var._Compare ) or &var._DIF = 0 then New_value = "-";
+    else New_value = put( &var._Compare, &fmt );
+
+  %end;
+  %else %do;
+
+    &var._DIF = compress( &var._DIF, '.' );
+
+    if missing( &var._Compare ) or missing( &var._DIF ) then New_value = "-";
+    else New_value = put( &var._Compare, &fmt );
+
+  %end;
+
+  %if %upcase( &except ) = Y %then %do;
+
+    if missing( &var._EXCEPT ) then Except_value = "-";
+    else Except_value = put( &var._EXCEPT, &fmt );
+
+    if New_value ~= "-" or Except_value ~= "-" then output;
+
+  %end;
+  %else %do;
+
+    Except_value = "n/a";
+    if New_value ~= "-" then output;
+
+  %end;
+
+%mend Update_rpt_write_var;
+
+/** End Macro Definition **/

--- a/jenner-check/t003_update_rpt_write_var/expected.json
+++ b/jenner-check/t003_update_rpt_write_var/expected.json
@@ -1,0 +1,12 @@
+{
+  "_captured_at": "2026-07-09T08:26:00Z",
+  "_captured_run_id": "r_2d313bda49604ae9b67353c42838fab7",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: Wrote update_report (2 rows, 4 columns).",
+    "NOTE: PROC PRINT completed: 2 observations printed, 4 variables"
+  ],
+  "log_does_not_contain": ["ERROR:", "[JENNER-ERROR"],
+  "diagnostics": {"parse_warnings": [], "runtime_warnings": []}
+}

--- a/jenner-check/t003_update_rpt_write_var/expected/log.txt
+++ b/jenner-check/t003_update_rpt_write_var/expected/log.txt
@@ -1,0 +1,11 @@
+NOTE: Option OBS changed to 100.
+NOTE: DATA update_report
+
+
+NOTE: Wrote update_report (2 rows, 4 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=update_report
+
+NOTE: PROC PRINT completed: 2 observations printed, 4 variables

--- a/jenner-check/t003_update_rpt_write_var/expected/output.txt
+++ b/jenner-check/t003_update_rpt_write_var/expected/output.txt
@@ -1,0 +1,4 @@
+Variable  Old  New  Exception
+----------------------  ---  ---  ---------
+Total units             100  120  -
+Owner-controlled units  50   -    60

--- a/jenner-check/t003_update_rpt_write_var/meta.json
+++ b/jenner-check/t003_update_rpt_write_var/meta.json
@@ -1,0 +1,7 @@
+{
+  "bundle": "t003_update_rpt_write_var",
+  "source_file": "Macros/Update_rpt_write_var.sas",
+  "source_blob_sha": "def289a9af1f18b3132204c57fccc744039dba34",
+  "source_commit": "ee29c6748c510be6af4c4b1180f0397a299a2f81",
+  "notes": "Repo autocall macro %Update_rpt_write_var copied verbatim into autoexec.sas. This is a statement-generating macro (emits assignment + conditional output statements inside a DATA step). script.sas builds one project's comparison record with three tracked variables (_Base/_Compare/_DIF/_EXCEPT suffixes as the update flow produces) and calls the macro once per variable. Exercises the macro's default numeric/except=y branch: a changed var and an exception-only var output, an unchanged var with no exception is dropped. No external deps."
+}

--- a/jenner-check/t003_update_rpt_write_var/script.sas
+++ b/jenner-check/t003_update_rpt_write_var/script.sas
@@ -1,0 +1,36 @@
+/**************************************************************************
+ Caller for the repo's %Update_rpt_write_var autocall macro
+ (Macros/Update_rpt_write_var.sas). In the catalog update flow, a comparison
+ step produces, for each tracked variable, a _Base value (current), a
+ _Compare value (proposed), a _DIF flag (0 = unchanged), and an optional
+ _EXCEPT override. The macro turns each of those into one report row of
+ Var / Old_value / New_value / Except_value, and only outputs a row when
+ something actually changed or an exception applies.
+
+ Here we build one project's comparison record with three tracked variables:
+   units      - changed (100 -> 120)
+   subsidized - unchanged (_DIF = 0, so it is dropped from the report)
+   ownercont  - unchanged in the compare, but has an exception override
+ and call the macro once per variable to assemble the report table.
+**************************************************************************/
+
+data update_report;
+
+  length Var $ 40 Old_value New_value Except_value $ 16;
+  keep Var Old_value New_value Except_value;
+
+  /* One project's comparison record. */
+  Units_Base = 100;      Units_Compare = 120;  Units_DIF = 20;   Units_EXCEPT = .;
+  Subsidized_Base = 80;  Subsidized_Compare = 80;  Subsidized_DIF = 0;  Subsidized_EXCEPT = .;
+  Ownercont_Base = 50;   Ownercont_Compare = 50;   Ownercont_DIF = 0;   Ownercont_EXCEPT = 60;
+
+  %Update_rpt_write_var( var=Units, lbl="Total units" )
+  %Update_rpt_write_var( var=Subsidized, lbl="Subsidized units" )
+  %Update_rpt_write_var( var=Ownercont, lbl="Owner-controlled units" )
+
+run;
+
+proc print data=update_report noobs label;
+  var Var Old_value New_value Except_value;
+  label Var = "Variable" Old_value = "Old" New_value = "New" Except_value = "Exception";
+run;

--- a/jenner-check/t004_create_place_name_list/autoexec.sas
+++ b/jenner-check/t004_create_place_name_list/autoexec.sas
@@ -1,0 +1,34 @@
+/* cap input rows for the captured run */
+options obs=100;
+
+/* Mock stand-ins for the two source tables the macro reads. In the repo these
+   are PresCat.Building_geocode (project buildings, keyed by bldg_address_id)
+   and Mar.Points_of_interest (MAR landmark/alias names, keyed by address_id).
+   Only the columns the macro touches are populated; the rows are invented so
+   the bundle is self-contained. */
+
+data Building_geocode;
+  length nlihc_id $ 16 bldg_address_id 8;
+  input nlihc_id $ bldg_address_id;
+  datalines;
+NL000046 101
+NL000046 102
+NL000093 201
+NL000319 301
+NL000319 302
+NL000319 303
+;
+run;
+
+data Points_of_interest;
+  length address_id 8 Place_name $ 80;
+  input address_id Place_name $char80.;
+  datalines;
+101 EDGEWOOD TERRACE
+102 EDGEWOOD COMMONS
+201 THE ARTHUR CAPPER SENIOR
+301 GALEN TERRACE
+302 GALEN STREET APARTMENTS
+303 SAVANNAH HEIGHTS
+;
+run;

--- a/jenner-check/t004_create_place_name_list/expected.json
+++ b/jenner-check/t004_create_place_name_list/expected.json
@@ -1,0 +1,13 @@
+{
+  "_captured_at": "2026-07-09T08:27:00Z",
+  "_captured_run_id": "r_9cd59d79e73343cda08dc6aada8c4db6",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: Table _Place_name created.",
+    "NOTE: Wrote Place_name_list_nlihc_id (3 rows, 2 columns).",
+    "NOTE: PROC PRINT completed: 3 observations printed, 2 variables"
+  ],
+  "log_does_not_contain": ["ERROR:", "[JENNER-ERROR"],
+  "diagnostics": {"parse_warnings": [], "runtime_warnings": []}
+}

--- a/jenner-check/t004_create_place_name_list/expected/log.txt
+++ b/jenner-check/t004_create_place_name_list/expected/log.txt
@@ -1,0 +1,38 @@
+NOTE: Option OBS changed to 100.
+NOTE: DATA Building_geocode
+
+NOTE: Processing inline DATALINES (6 lines)
+
+NOTE: Read 6 rows from DATALINES.
+NOTE: Wrote Building_geocode (6 rows, 2 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: DATA Points_of_interest
+
+NOTE: Processing inline DATALINES (6 lines)
+
+NOTE: Read 6 rows from DATALINES.
+NOTE: Wrote Points_of_interest (6 rows, 2 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC SQL 
+
+NOTE: Table _Place_name created.
+NOTE: PROC SQL statement used.
+NOTE: DATA Place_name_list_nlihc_id
+
+
+NOTE: Read 6 rows from _Place_name.
+NOTE: Wrote Place_name_list_nlihc_id (3 rows, 2 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC DATASETS library=WORK
+
+NOTE: Deleting _PLACE_NAME (memtype=DATA).
+NOTE: 1 dataset(s) deleted.
+NOTE: PROC PRINT data=Place_name_list_nlihc_id
+
+NOTE: PROC PRINT completed: 3 observations printed, 2 variables

--- a/jenner-check/t004_create_place_name_list/expected/output.txt
+++ b/jenner-check/t004_create_place_name_list/expected/output.txt
@@ -1,0 +1,5 @@
+Project ID             List of MAR point of interest names (aliases)
+----------  --------------------------------------------------------
+NL000046    Edgewood Commons; Edgewood Terrace
+NL000093    The Arthur Capper Senior
+NL000319    Galen Street Apartments; Galen Terrace; Savannah Heights

--- a/jenner-check/t004_create_place_name_list/meta.json
+++ b/jenner-check/t004_create_place_name_list/meta.json
@@ -1,0 +1,7 @@
+{
+  "bundle": "t004_create_place_name_list",
+  "source_file": "Macros/Create_place_name_list.sas",
+  "source_blob_sha": "006168b8805697d2174103e4aae06574dd05222b",
+  "source_commit": "ee29c6748c510be6af4c4b1180f0397a299a2f81",
+  "notes": "Repo autocall macro %Create_place_name_list. Copied faithfully; the only change is the two-level source names in the PROC SQL (PresCat.Building_geocode, Mar.Points_of_interest) redirected to WORK stand-ins built in autoexec.sas so the bundle needs no external libraries. The macro logic (coalesce/left-join to gather POI names, retain + catx with first./last. to collapse to a semicolon-delimited alias list per project) is unchanged. Called with by=nlihc_id over 6 mock building addresses spanning 3 projects."
+}

--- a/jenner-check/t004_create_place_name_list/script.sas
+++ b/jenner-check/t004_create_place_name_list/script.sas
@@ -1,0 +1,69 @@
+/**************************************************************************
+ The repo's %Create_place_name_list autocall macro
+ (Macros/Create_place_name_list.sas), copied with one substitution: the
+ two-level source names PresCat.Building_geocode and Mar.Points_of_interest
+ in the PROC SQL are pointed at the WORK stand-ins built in autoexec.sas, so
+ the bundle needs no external libraries. The macro's logic is unchanged: a
+ coalesce/left-join gathers the MAR point-of-interest names for each
+ project's building addresses, then a retain + catx pass with first./last.
+ collapses them into one semicolon-delimited alias list per BY value.
+
+ We then call it with by=nlihc_id and print the resulting alias lists.
+**************************************************************************/
+
+%macro Create_place_name_list( by=, data=Building_geocode, out=Place_name_list_&by );
+
+  ** Reduce Place_name to one per &BY= value **;
+
+  proc sql noprint;
+    create table _Place_name as
+    select distinct &by, Place_name from
+    (
+      select
+        coalesce( Addr.bldg_address_id, POI.address_id ) as match_address_id, Addr.&by, POI.Place_name
+        from Building_geocode as Addr left join Points_of_interest as POI
+      on Addr.bldg_address_id = POI.address_id
+      where not( missing( POI.Place_name ) )
+    )
+    order by &by, Place_name;
+  quit;
+
+  data &out;
+
+    set _Place_name;
+    by &by;
+
+    retain Place_name_list;
+
+    length Place_name_list $ 1000;
+
+    if first.&by then do;
+      Place_name_list = "";
+    end;
+
+    Place_name_list = catx( '; ', Place_name_list, propcase( Place_name ) );
+
+    if last.&by then output;
+
+    drop Place_name;
+
+    label
+      Place_name_list = "List of MAR point of interest names (aliases)";
+
+  run;
+
+  ** Clean up temporary files **;
+
+  proc datasets library=Work memtype=(data) nolist;
+    delete _Place_name;
+  quit;
+  run;
+
+%mend Create_place_name_list;
+
+%Create_place_name_list( by=nlihc_id )
+
+proc print data=Place_name_list_nlihc_id noobs label;
+  var nlihc_id Place_name_list;
+  label nlihc_id = "Project ID";
+run;

--- a/jenner-check/t005_dcinfo_corrections/autoexec.sas
+++ b/jenner-check/t005_dcinfo_corrections/autoexec.sas
@@ -1,0 +1,26 @@
+/* cap input rows for the captured run */
+options obs=100;
+
+/* The following %macro is copied verbatim from Macros/DCInfo_corrections.sas
+   in this repo. It applies hand-entered corrections to catalog records
+   (reassigning a duplicated NLIHC_ID and fixing a known unit count/category)
+   and is meant to be invoked inside a DATA step. The caller in script.sas
+   supplies a small set of records covering exactly the rows it corrects. */
+
+/** Macro Corrections - Start Definition **/
+
+%macro DCInfo_corrections(  );
+
+  ** Assign new NLIHC_ID to St. Dennis (duplicate ID with CEMI - Bethune House) **;
+
+  if NLIHC_ID = "NL001007" and upcase( Proj_Name ) = "ST. DENNIS" then
+    NLIHC_ID = "NL001030";
+
+  if NLIHC_ID = "NL000046" then do;
+    units = 535;
+    Category = "1";
+  end;
+
+%mend DCInfo_corrections;
+
+/** End Macro Definition **/

--- a/jenner-check/t005_dcinfo_corrections/expected.json
+++ b/jenner-check/t005_dcinfo_corrections/expected.json
@@ -1,0 +1,12 @@
+{
+  "_captured_at": "2026-07-09T08:28:00Z",
+  "_captured_run_id": "r_a738e07b66c348cb97a643e434010659",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "NOTE: Wrote catalog_corrected (4 rows, 4 columns).",
+    "NOTE: PROC PRINT completed: 4 observations printed, 4 variables"
+  ],
+  "log_does_not_contain": ["ERROR:", "[JENNER-ERROR"],
+  "diagnostics": {"parse_warnings": [], "runtime_warnings": []}
+}

--- a/jenner-check/t005_dcinfo_corrections/expected/log.txt
+++ b/jenner-check/t005_dcinfo_corrections/expected/log.txt
@@ -1,0 +1,24 @@
+NOTE: Option OBS changed to 100.
+NOTE: DATA catalog_raw
+
+NOTE: Processing inline DATALINES (4 lines)
+
+NOTE: Read 4 rows from DATALINES.
+NOTE: Wrote catalog_raw (4 rows, 4 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: DATA catalog_corrected
+
+
+NOTE: Read 4 rows from catalog_raw.
+NOTE: Wrote catalog_corrected (4 rows, 4 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=catalog_raw
+
+NOTE: PROC PRINT completed: 4 observations printed, 4 variables
+NOTE: PROC PRINT data=catalog_corrected
+
+NOTE: PROC PRINT completed: 4 observations printed, 4 variables

--- a/jenner-check/t005_dcinfo_corrections/expected/output.txt
+++ b/jenner-check/t005_dcinfo_corrections/expected/output.txt
@@ -1,0 +1,15 @@
+Before corrections                                                   
+
+ID (before)                                   Project  Category  units
+NL001007     St. Dennis                                5            40
+NL001007     Bethune House                             5            60
+NL000046     Edgewood Terrace                          4           500
+NL000093     Brookland Manor                           2           535
+
+                                                   After corrections                                                    
+
+ID (after)                                   Project  Category  units
+NL001030    St. Dennis                                5            40
+NL001007    Bethune House                             5            60
+NL000046    Edgewood Terrace                          1           535
+NL000093    Brookland Manor                           2           535

--- a/jenner-check/t005_dcinfo_corrections/meta.json
+++ b/jenner-check/t005_dcinfo_corrections/meta.json
@@ -1,0 +1,7 @@
+{
+  "bundle": "t005_dcinfo_corrections",
+  "source_file": "Macros/DCInfo_corrections.sas",
+  "source_blob_sha": "6436329309e70c9aa3873c648591e77f0e68cd23",
+  "source_commit": "ee29c6748c510be6af4c4b1180f0397a299a2f81",
+  "notes": "Repo autocall macro %DCInfo_corrections copied verbatim into autoexec.sas (conditional record fixes inside a DATA step). script.sas supplies 4 records: the two rows it targets (St. Dennis NL001007 reassigned to NL001030; NL000046 units/category fixed), a lookalike sharing NL001007 that must be left alone, and an unrelated row. Before/after PROC PRINTs show only the intended rows change. No external deps. Note: an earlier caller draft put %DCInfo_corrections inside a quoted TITLE string, which SAS macro-resolves - that was a caller mistake, corrected to a literal title."
+}

--- a/jenner-check/t005_dcinfo_corrections/script.sas
+++ b/jenner-check/t005_dcinfo_corrections/script.sas
@@ -1,0 +1,40 @@
+/**************************************************************************
+ Caller for the repo's %DCInfo_corrections autocall macro
+ (Macros/DCInfo_corrections.sas). The macro carries two hand-entered fixes:
+ St. Dennis carries the duplicate ID NL001007 (shared with Bethune House) and
+ is reassigned to NL001030, and NL000046's unit count and category are set to
+ their known-correct values (535 units, category 1).
+
+ We feed it four records: the two rows it targets, a lookalike that shares
+ NL001007 but is NOT St. Dennis (must be left alone), and an unrelated row.
+ The before/after print shows only the intended rows change.
+**************************************************************************/
+
+data catalog_raw;
+  length NLIHC_ID $ 16 Proj_Name $ 40 Category $ 1 units 8;
+  input NLIHC_ID $ Proj_Name $char40. Category $ units;
+  datalines;
+NL001007 St. Dennis                              5 40
+NL001007 Bethune House                           5 60
+NL000046 Edgewood Terrace                        4 500
+NL000093 Brookland Manor                         2 535
+;
+run;
+
+data catalog_corrected;
+  set catalog_raw;
+  %DCInfo_corrections()
+run;
+
+proc print data=catalog_raw noobs label;
+  var NLIHC_ID Proj_Name Category units;
+  label NLIHC_ID = "ID (before)" Proj_Name = "Project";
+  title "Before corrections";
+run;
+
+proc print data=catalog_corrected noobs label;
+  var NLIHC_ID Proj_Name Category units;
+  label NLIHC_ID = "ID (after)" Proj_Name = "Project";
+  title "After corrections";
+run;
+title;


### PR DESCRIPTION
`Make_formats.sas` and several of the `Macros/` autocall macros from this repo run unmodified on [Jenner](https://jenneranalytics.com), a SAS-compatible engine we develop. This PR adds one optional, self-contained directory, `jenner-check/`, holding five small bundles: each is a byte-for-byte copy (or a faithful caller) of one of your programs, the captured log and listing from running it, and a short shell runner. Nothing outside `jenner-check/` is touched, nothing runs on merge, and there are no workflow files or hooks.

Reading through the `Macros/` library, the thing that stood out was how carefully the name-cleaning macros order their fixups. `Project_name_clean` and `Owner_name_clean` both run `propcase()` first and then repair everything propcase gets wrong, and the sequencing is deliberate: `Iii -> III` has to fire before `Ii -> II` or you would strand a half-cased "IIi", and the quadrant guards (`Ne -> NE`, then `NEw -> New`) undo the collateral damage the first pass causes. It reads like rules accreted one surprising DC project name at a time, which is exactly how this kind of code earns its keep. `Update_rpt_write_var` was the other one I enjoyed reading, for how it collapses the base/compare/exception three-way into a single report row.

Here is the layout, and one of the bundles you can run in one line:

```
jenner-check/
├── run_jenner.sh                     # re-runs a bundle (or all of them) and checks the pinned output
├── README.md
├── t001_project_name_clean/          # caller for %Project_name_clean
├── t002_make_formats/                # subset of Make_formats.sas ($Status, $Categry, $Infosrc, ...)
├── t003_update_rpt_write_var/        # caller for %Update_rpt_write_var
├── t004_create_place_name_list/      # %Create_place_name_list over mock MAR/geocode tables
└── t005_dcinfo_corrections/          # caller for %DCInfo_corrections
```

```bash
# Check out this PR (puts you on its branch); then run from the repo root:
gh pr checkout 513
curl -sS --data-binary @jenner-check/t002_make_formats/script.sas https://api.jenneranalytics.com/v1/quick
```

Running `cd jenner-check && ./run_jenner.sh --all` re-runs every bundle and verifies the pinned fields in each `expected.json`. The hosted API is free to try with no signup; full API reference is in [the docs](https://docs.jenneranalytics.com/api/).

On what leaves your machine: the runner uploads only the SAS source text of the script it runs (plus a two-line autoexec that sets `options obs=100`) to api.jenneranalytics.com, which runs it and returns the log and listing. It does not read or upload any data files, so anything sitting next to a script stays on your machine, and nothing is sent unless you run a command yourself. The only thing transmitted is the code you choose to run, the same as pasting a snippet into any hosted tool, so you can review a script first if it has values inline.

We validate Jenner against public SAS code, and this bundle is the test we wrote for your repo, offered back in case it is useful. It was put together with AI assistance and read over by a person before sending. This account is operated by the Jenner project, which is accountable for what it opens. Merge it, close it, or ignore it, whichever suits you — no reply is expected, and we will not open further PRs here. To opt out of any future contact, put `no-more-prs` in a comment or open an issue titled `jenner-check: opt out`.